### PR TITLE
Fix critical race conditions in position management + lifecycle tracking

### DIFF
--- a/database/db_manager.py
+++ b/database/db_manager.py
@@ -110,7 +110,11 @@ ALTER TABLE trades_history
 ADD COLUMN IF NOT EXISTS pnl_net DOUBLE PRECISION,
 ADD COLUMN IF NOT EXISTS commission DOUBLE PRECISION,
 ADD COLUMN IF NOT EXISTS swap DOUBLE PRECISION,
-ADD COLUMN IF NOT EXISTS fee DOUBLE PRECISION;
+ADD COLUMN IF NOT EXISTS fee DOUBLE PRECISION,
+ADD COLUMN IF NOT EXISTS exit_reason TEXT,
+ADD COLUMN IF NOT EXISTS mt5_ticket BIGINT,
+ADD COLUMN IF NOT EXISTS sl_price DOUBLE PRECISION,
+ADD COLUMN IF NOT EXISTS tp_price DOUBLE PRECISION;
 """
 
 _CREATE_COMMANDS = """
@@ -148,6 +152,7 @@ SET exit_price = $2,
     commission = $6,
     swap       = $7,
     fee        = $8,
+    exit_reason = $9,
     status     = 'closed'
 WHERE id = $1;
 """
@@ -443,15 +448,17 @@ class DatabaseManager:
         commission: float = 0.0,
         swap: float = 0.0,
         fee: float = 0.0,
+        exit_reason: str = "",
     ) -> None:
         """Update a trade record in *trades_history* to mark it as closed.
 
         Parameters
         ----------
-        trade_id:   Row id of the trade to close.
-        exit_price: Price at which the trade was exited.
-        exit_time:  Trade exit time (UTC).  Defaults to *now*.
-        pnl:        Realised profit / loss in quote currency.
+        trade_id:    Row id of the trade to close.
+        exit_price:  Price at which the trade was exited.
+        exit_time:   Trade exit time (UTC).  Defaults to *now*.
+        pnl:         Realised profit / loss in quote currency.
+        exit_reason: Exit reason code (e.g. SL_BASE, TRAILING_STOP, SMART_EXIT_ML).
         """
         if self._pool is None:
             raise RuntimeError("DatabaseManager is not connected. Call connect() first.")
@@ -467,6 +474,7 @@ class DatabaseManager:
                 commission,
                 swap,
                 fee,
+                exit_reason,
             )
 
     async def upsert_htf_trend(

--- a/execution/mt5_executor.py
+++ b/execution/mt5_executor.py
@@ -1376,52 +1376,6 @@ class MT5Executor(PaperExecutor):
         """
         sym = symbol or self.symbol
 
-        # ── Duplicate and circuit-breaker checks (inherited logic) ─────────
-        if self._risk.is_trading_halted():
-            logger.warning(
-                "⚠️ [ALERT] Trading halted due to daily loss limit (symbol=%s).",
-                sym,
-            )
-            return False
-
-        if self._risk.is_portfolio_dd_exceeded():
-            logger.warning(
-                "🚨 [CIRCUIT BREAKER] All new positions blocked – "
-                "portfolio drawdown limit reached (symbol=%s).",
-                sym,
-            )
-            return False
-
-        if sym in self.open_positions:
-            logger.debug("Trade skipped – a position for %s is already open.", sym)
-            return False
-
-        if not self._risk.can_open_position():
-            logger.debug(
-                "Trade skipped – max open positions (%d) reached.",
-                self._risk.max_positions,
-            )
-            return False
-
-        if self._risk.is_sector_exposed(sym, list(self.open_positions.keys())):
-            sector = get_sector(sym)
-            logger.warning(
-                "🛡️ [RISK CONTROL] BUY signal for %s ignored – "
-                "maximum sector exposure reached: %s.",
-                sym,
-                sector,
-            )
-            return False
-
-        position_size = self._risk.calculate_position_size(win_probability)
-        if not self._risk.has_sufficient_balance(position_size):
-            logger.warning(
-                "⚠️ [ALERT] Insufficient balance (%.2f) for position size %.2f.",
-                self._risk.balance,
-                position_size,
-            )
-            return False
-
         # ── MT5 symbol resolution (fail-fast before any state mutation) ────
         mt5_sym: str | None = None
         if self._live:
@@ -1429,9 +1383,55 @@ class MT5Executor(PaperExecutor):
             if mt5_sym is None:
                 return False
 
-        ts = timestamp or datetime.now(tz=timezone.utc)
-        # self._risk.deduct(position_size)  <-- Removed to avoid false drawdown triggers
-        self._risk.register_open()
+        # ── All pre-checks under lock to prevent race conditions ───────────
+        async with self._positions_lock:
+            if self._risk.is_trading_halted():
+                logger.warning(
+                    "⚠️ [ALERT] Trading halted due to daily loss limit (symbol=%s).",
+                    sym,
+                )
+                return False
+
+            if self._risk.is_portfolio_dd_exceeded():
+                logger.warning(
+                    "🚨 [CIRCUIT BREAKER] All new positions blocked – "
+                    "portfolio drawdown limit reached (symbol=%s).",
+                    sym,
+                )
+                return False
+
+            if sym in self.open_positions:
+                logger.debug("Trade skipped – a position for %s is already open.", sym)
+                return False
+
+            if not self._risk.can_open_position():
+                logger.debug(
+                    "Trade skipped – max open positions (%d) reached.",
+                    self._risk.max_positions,
+                )
+                return False
+
+            if self._risk.is_sector_exposed(sym, list(self.open_positions.keys())):
+                sector = get_sector(sym)
+                logger.warning(
+                    "🛡️ [RISK CONTROL] BUY signal for %s ignored – "
+                    "maximum sector exposure reached: %s.",
+                    sym,
+                    sector,
+                )
+                return False
+
+            position_size = self._risk.calculate_position_size(win_probability)
+            if not self._risk.has_sufficient_balance(position_size):
+                logger.warning(
+                    "⚠️ [ALERT] Insufficient balance (%.2f) for position size %.2f.",
+                    self._risk.balance,
+                    position_size,
+                )
+                return False
+
+            ts = timestamp or datetime.now(tz=timezone.utc)
+            self._risk.register_open()
 
         # ── Dynamic risk thresholds from sentiment ─────────────────────────
         thresholds: DynamicThresholds = get_dynamic_thresholds(sentiment_score)
@@ -1540,32 +1540,40 @@ class MT5Executor(PaperExecutor):
             result = await self._send_order_with_retry(request)
             if result is None:
                 # Order rejected – roll back counter (balance wasn't deducted)
-                self._risk.register_close()
+                async with self._positions_lock:
+                    self._risk.register_close()
                 return False
             mt5_ticket = await self._resolve_position_ticket_after_buy(mt5_sym, result)
 
-        trade_id = await self._db.insert_open_trade(
-            symbol=sym,
-            entry_price=entry_price,
-            position_size=position_size,
-            entry_time=ts,
-        )
+        try:
+            trade_id = await self._db.insert_open_trade(
+                symbol=sym,
+                entry_price=entry_price,
+                position_size=position_size,
+                entry_time=ts,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[MT5][DB] insert_open_trade failed for %s — rolling back: %s", sym, exc)
+            async with self._positions_lock:
+                self._risk.register_close()
+            return False
 
-        self.open_positions[sym] = OpenPosition(
-            symbol=sym,
-            entry_price=entry_price,
-            position_size=position_size,
-            entry_time=ts,
-            trade_id=trade_id,
-            sl_pct=thresholds.sl_pct,
-            activation_pct=thresholds.activation_pct,
-            trailing_distance_pct=thresholds.trailing_distance_pct,
-            stop_loss_price=stop_loss_price,
-            atr_trailing_distance=atr_trailing_distance,
-            ml_confidence=win_probability,
-            sentiment_score=sentiment_score,
-            mt5_position_ticket=mt5_ticket,
-        )
+        async with self._positions_lock:
+            self.open_positions[sym] = OpenPosition(
+                symbol=sym,
+                entry_price=entry_price,
+                position_size=position_size,
+                entry_time=ts,
+                trade_id=trade_id,
+                sl_pct=thresholds.sl_pct,
+                activation_pct=thresholds.activation_pct,
+                trailing_distance_pct=thresholds.trailing_distance_pct,
+                stop_loss_price=stop_loss_price,
+                atr_trailing_distance=atr_trailing_distance,
+                ml_confidence=win_probability,
+                sentiment_score=sentiment_score,
+                mt5_position_ticket=mt5_ticket,
+            )
 
         record_trade(
             timestamp=ts,
@@ -1666,6 +1674,7 @@ class MT5Executor(PaperExecutor):
                     commission=commission,
                     swap=swap,
                     fee=fee,
+                    exit_reason=exit_reason_code,
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.exception(
@@ -1674,13 +1683,15 @@ class MT5Executor(PaperExecutor):
                     exc,
                 )
 
-        self._risk.credit(gross_pnl)
-        self._risk.register_close()
-        if gross_pnl < 0.0:
-            self._risk.record_daily_loss(-gross_pnl)
-        self.total_pnl += gross_pnl
-        sym_ref = pos.symbol
-        del self.open_positions[symbol]
+        async with self._positions_lock:
+            self._risk.credit(gross_pnl)
+            self._risk.register_close()
+            if gross_pnl < 0.0:
+                self._risk.record_daily_loss(-gross_pnl)
+            self.total_pnl += gross_pnl
+            sym_ref = pos.symbol
+            if symbol in self.open_positions:
+                del self.open_positions[symbol]
 
         margin_used = pos.position_size / LEVERAGE
         pnl_pct = (pnl_net / margin_used * 100) if margin_used > 0 else 0.0
@@ -1756,7 +1767,8 @@ class MT5Executor(PaperExecutor):
 
     async def _reconcile_ghost_position(self, sym: str) -> None:
         """Ghost = local open but MT5 has no position; close DB + notify."""
-        pos = self.open_positions.get(sym)
+        async with self._positions_lock:
+            pos = self.open_positions.get(sym)
         if pos is None:
             return
         mt5_sym = self._resolve_symbol(sym)
@@ -1870,8 +1882,12 @@ class MT5Executor(PaperExecutor):
         if tp_raw > 0.0:
             op.last_broker_tp_synced = self._normalize_price(tp_raw, digits)
 
-        self.open_positions[sym] = op
-        self._risk.register_open()
+        async with self._positions_lock:
+            if sym in self.open_positions:
+                logger.debug("_try_adopt_mt5_position: %s already tracked — skipping.", sym)
+                return False
+            self.open_positions[sym] = op
+            self._risk.register_open()
 
         record_trade(
             timestamp=ts,
@@ -2114,12 +2130,14 @@ class MT5Executor(PaperExecutor):
         }
 
         # Ghost detection — broker closed without bot bookkeeping (SL/TP / manual)
-        ghost_symbols = [sym for sym in self.open_positions if sym not in live_symbols]
+        async with self._positions_lock:
+            ghost_symbols = [sym for sym in self.open_positions if sym not in live_symbols]
         for sym in ghost_symbols:
             await self._reconcile_ghost_position(sym)
 
         # Broker-only positions → import into local book (LONG + our magic)
-        untracked = [sym for sym in live_symbols if sym not in self.open_positions]
+        async with self._positions_lock:
+            untracked = [sym for sym in live_symbols if sym not in self.open_positions]
         for sym in untracked:
             adopted = await self._try_adopt_mt5_position(sym)
             if not adopted:
@@ -2128,6 +2146,17 @@ class MT5Executor(PaperExecutor):
                     "(adoption failed — check logs).",
                     sym,
                 )
+
+        # Enforce counter invariant after sync
+        async with self._positions_lock:
+            actual = len(self.open_positions)
+            if self._risk.open_count != actual:
+                logger.warning(
+                    "[MT5 SYNC] Counter drift detected: risk.open_count=%d actual=%d — correcting.",
+                    self._risk.open_count,
+                    actual,
+                )
+                self._risk.sync_open_count(actual)
 
         return len(live_symbols)
 

--- a/execution/paper_executor.py
+++ b/execution/paper_executor.py
@@ -721,29 +721,24 @@ class PaperExecutor:
                 return False
 
             ts = timestamp or datetime.now(tz=timezone.utc)
-            # self._risk.deduct(position_size)  <-- Removed to avoid Circuit Breaker false positives
             self._risk.register_open()
 
-        # ── Compute dynamic risk thresholds from sentiment ─────────────────
-        thresholds: DynamicThresholds = get_dynamic_thresholds(sentiment_score)
-        logger.debug(
-            "DYNAMIC THRESHOLDS  symbol=%s  sentiment=%.4f  multiplier=%.2f  "
-            "sl=%.4f  activation=%.4f  trailing_dist=%.4f",
-            sym,
-            sentiment_score,
-            thresholds.multiplier,
-            thresholds.sl_pct,
-            thresholds.activation_pct,
-            thresholds.trailing_distance_pct,
-        )
+            # ── Compute dynamic risk thresholds from sentiment ─────────────
+            thresholds: DynamicThresholds = get_dynamic_thresholds(sentiment_score)
+            logger.debug(
+                "DYNAMIC THRESHOLDS  symbol=%s  sentiment=%.4f  multiplier=%.2f  "
+                "sl=%.4f  activation=%.4f  trailing_dist=%.4f",
+                sym,
+                sentiment_score,
+                thresholds.multiplier,
+                thresholds.sl_pct,
+                thresholds.activation_pct,
+                thresholds.trailing_distance_pct,
+            )
 
         # ── Live Binance Futures order ─────────────────────────────────────
         if self._exchange is not None:
             try:
-                # Set leverage at the symbol level (required by Binance Futures).
-                # On Testnet this call may fail with NotSupported because there
-                # is no sapi URL for the sandbox; in that case log a warning and
-                # proceed with the order using whatever leverage is already set.
                 try:
                     await self._exchange.set_leverage(LEVERAGE, sym)
                 except CcxtNotSupported:
@@ -752,8 +747,6 @@ class PaperExecutor:
                         "proceeding with existing leverage setting.",
                         sym,
                     )
-                # position_size is the leveraged notional value; convert to base
-                # currency quantity by dividing by the entry price.
                 amount = position_size / entry_price
                 try:
                     await self._exchange.create_market_buy_order(
@@ -762,9 +755,6 @@ class PaperExecutor:
                         params={"leverage": LEVERAGE},
                     )
                 except CcxtNotSupported:
-                    # Testnet sapi endpoints are not available; the fapi order
-                    # may still have been routed correctly.  Log a warning and
-                    # continue rather than treating this as a hard failure.
                     logger.warning(
                         "create_market_buy_order raised NotSupported for %s "
                         "(testnet sapi metadata unavailable). "
@@ -786,43 +776,48 @@ class PaperExecutor:
                     "rolling back balance deduction and aborting trade.",
                     sym,
                 )
-                # Roll back the balance deduction and open-position counter that
-                # were applied before the order attempt.  No paper position should
-                # be recorded because no real order was submitted successfully.
-                self._risk.credit(position_size)
-                self._risk.register_close()
+                async with self._positions_lock:
+                    self._risk.credit(position_size)
+                    self._risk.register_close()
                 return False
 
-        trade_id = await self._db.insert_open_trade(
-            symbol=sym,
-            entry_price=entry_price,
-            position_size=position_size,
-            entry_time=ts,
-        )
+        try:
+            trade_id = await self._db.insert_open_trade(
+                symbol=sym,
+                entry_price=entry_price,
+                position_size=position_size,
+                entry_time=ts,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[DB] insert_open_trade failed for %s — rolling back: %s", sym, exc)
+            async with self._positions_lock:
+                self._risk.register_close()
+            return False
 
         # ── ATR-based dynamic SL / trailing distance ───────────────────────
         sl_distance: float | None = None
-        stop_loss_price: float = 0.0  # 0.0 → __post_init__ derives from sl_pct
-        atr_trailing_distance: float = 0.0  # 0.0 → use pct-based trailing
+        stop_loss_price: float = 0.0
+        atr_trailing_distance: float = 0.0
         if current_atr is not None and current_atr > 0.0:
             sl_distance = current_atr * ATR_SL_MULTIPLIER
-            stop_loss_price = entry_price - sl_distance  # LONG position
+            stop_loss_price = entry_price - sl_distance
             atr_trailing_distance = current_atr * ATR_TRAILING_MULTIPLIER
 
-        self.open_positions[sym] = OpenPosition(
-            symbol=sym,
-            entry_price=entry_price,
-            position_size=position_size,
-            entry_time=ts,
-            trade_id=trade_id,
-            sl_pct=thresholds.sl_pct,
-            activation_pct=thresholds.activation_pct,
-            trailing_distance_pct=thresholds.trailing_distance_pct,
-            stop_loss_price=stop_loss_price,
-            atr_trailing_distance=atr_trailing_distance,
-            ml_confidence=win_probability,
-            sentiment_score=sentiment_score,
-        )
+        async with self._positions_lock:
+            self.open_positions[sym] = OpenPosition(
+                symbol=sym,
+                entry_price=entry_price,
+                position_size=position_size,
+                entry_time=ts,
+                trade_id=trade_id,
+                sl_pct=thresholds.sl_pct,
+                activation_pct=thresholds.activation_pct,
+                trailing_distance_pct=thresholds.trailing_distance_pct,
+                stop_loss_price=stop_loss_price,
+                atr_trailing_distance=atr_trailing_distance,
+                ml_confidence=win_probability,
+                sentiment_score=sentiment_score,
+            )
         # ── Trade journal CSV (BUY row) ────────────────────────────────────
         record_trade(
             timestamp=ts,
@@ -1249,6 +1244,7 @@ class PaperExecutor:
                     pnl=pnl,
                     pnl_net=net_pnl,
                     fee=total_fees,
+                    exit_reason=exit_reason_code,
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.exception(
@@ -1358,6 +1354,16 @@ class PaperExecutor:
                     len(self.open_positions),
                     len(live_symbols),
                 )
+
+            # Enforce counter invariant after sync
+            actual = len(self.open_positions)
+            if self._risk.open_count != actual:
+                logger.warning(
+                    "[SYNC] Counter drift detected: risk.open_count=%d actual=%d — correcting.",
+                    self._risk.open_count,
+                    actual,
+                )
+                self._risk.sync_open_count(actual)
 
         return len(live_symbols)
 

--- a/tests/test_position_limits.py
+++ b/tests/test_position_limits.py
@@ -1,0 +1,224 @@
+"""Tests for position limit enforcement and race condition prevention.
+
+Validates:
+- max_positions limit is respected
+- Duplicate symbol prevention works
+- Counter invariant is maintained after sync
+- register_open/register_close rollback on failures
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from risk.risk_manager import RiskManager
+
+
+@pytest.fixture
+def risk_manager() -> RiskManager:
+    return RiskManager(initial_balance=10_000.0, max_positions=3)
+
+
+def test_can_open_position_respects_max(risk_manager: RiskManager) -> None:
+    """Verify can_open_position blocks after max_positions reached."""
+    assert risk_manager.can_open_position() is True
+    risk_manager.register_open()
+    assert risk_manager.can_open_position() is True
+    risk_manager.register_open()
+    assert risk_manager.can_open_position() is True
+    risk_manager.register_open()
+    assert risk_manager.can_open_position() is False
+
+
+def test_register_close_below_zero(risk_manager: RiskManager) -> None:
+    """Verify register_close doesn't go below 0."""
+    assert risk_manager.open_count == 0
+    risk_manager.register_close()
+    assert risk_manager.open_count == 0
+
+
+def test_sync_open_count(risk_manager: RiskManager) -> None:
+    """Verify sync_open_count corrects drift."""
+    risk_manager.register_open()
+    risk_manager.register_open()
+    assert risk_manager.open_count == 2
+    risk_manager.sync_open_count(1)
+    assert risk_manager.open_count == 1
+    assert risk_manager.can_open_position() is True
+
+
+def test_sync_open_count_negative_clamped(risk_manager: RiskManager) -> None:
+    """Verify sync_open_count clamps negative to 0."""
+    risk_manager.sync_open_count(-5)
+    assert risk_manager.open_count == 0
+
+
+def test_sector_exposure_blocks_duplicate_sector(risk_manager: RiskManager) -> None:
+    """Same sector = blocked."""
+    assert risk_manager.is_sector_exposed("BTC/USDT", []) is False
+    assert risk_manager.is_sector_exposed("BTC/USDT", ["ETH/USDT"]) is False
+    assert risk_manager.is_sector_exposed("LINK/USDT", ["INJ/USDT"]) is True
+
+
+@pytest.fixture
+def mock_db() -> AsyncMock:
+    db = AsyncMock()
+    db.insert_open_trade = AsyncMock(return_value=1)
+    db.close_trade = AsyncMock()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_paper_executor_duplicate_symbol_rejected(
+    risk_manager: RiskManager, mock_db: AsyncMock
+) -> None:
+    """Verify a second open on the same symbol is rejected."""
+    from execution.paper_executor import PaperExecutor
+
+    executor = PaperExecutor(db=mock_db, risk_manager=risk_manager)
+    opened = await executor.try_open_trade(
+        entry_price=100.0,
+        win_probability=0.7,
+        symbol="BTC/USDT",
+        sentiment_score=0.0,
+    )
+    assert opened is True
+    assert risk_manager.open_count == 1
+
+    opened2 = await executor.try_open_trade(
+        entry_price=100.0,
+        win_probability=0.7,
+        symbol="BTC/USDT",
+        sentiment_score=0.0,
+    )
+    assert opened2 is False
+    assert risk_manager.open_count == 1
+
+
+@pytest.mark.asyncio
+async def test_paper_executor_max_positions_respected(
+    risk_manager: RiskManager, mock_db: AsyncMock
+) -> None:
+    """Verify 4th position on a max_positions=3 executor is blocked."""
+    from execution.paper_executor import PaperExecutor
+
+    executor = PaperExecutor(db=mock_db, risk_manager=risk_manager)
+    symbols = ["BTC/USDT", "ETH/USDT", "SOL/USDT", "BNB/USDT"]
+    results = []
+    for sym in symbols:
+        opened = await executor.try_open_trade(
+            entry_price=100.0,
+            win_probability=0.7,
+            symbol=sym,
+            sentiment_score=0.0,
+        )
+        results.append(opened)
+
+    assert results == [True, True, True, False]
+    assert risk_manager.open_count == 3
+    assert len(executor.open_positions) == 3
+
+
+@pytest.mark.asyncio
+async def test_paper_executor_counter_matches_dict(
+    risk_manager: RiskManager, mock_db: AsyncMock
+) -> None:
+    """Verify the risk counter stays in sync with open_positions dict."""
+    from execution.paper_executor import PaperExecutor
+
+    executor = PaperExecutor(db=mock_db, risk_manager=risk_manager)
+    await executor.try_open_trade(
+        entry_price=100.0,
+        win_probability=0.7,
+        symbol="BTC/USDT",
+    )
+    assert risk_manager.open_count == len(executor.open_positions) == 1
+
+    await executor.try_open_trade(
+        entry_price=50.0,
+        win_probability=0.7,
+        symbol="ETH/USDT",
+    )
+    assert risk_manager.open_count == len(executor.open_positions) == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_open_same_symbol_only_one_succeeds(
+    risk_manager: RiskManager, mock_db: AsyncMock
+) -> None:
+    """Simulate two concurrent try_open_trade calls for the same symbol.
+    
+    Only one should succeed (the lock prevents race conditions).
+    """
+    from execution.paper_executor import PaperExecutor
+
+    executor = PaperExecutor(db=mock_db, risk_manager=risk_manager)
+
+    results = await asyncio.gather(
+        executor.try_open_trade(entry_price=100.0, win_probability=0.7, symbol="BTC/USDT"),
+        executor.try_open_trade(entry_price=100.0, win_probability=0.7, symbol="BTC/USDT"),
+    )
+    assert sum(results) == 1
+    assert risk_manager.open_count == 1
+    assert len(executor.open_positions) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_open_exceeding_max_positions(
+    risk_manager: RiskManager, mock_db: AsyncMock
+) -> None:
+    """Simulate 5 concurrent opens on max_positions=3. At most 3 succeed."""
+    from execution.paper_executor import PaperExecutor
+
+    executor = PaperExecutor(db=mock_db, risk_manager=risk_manager)
+    symbols = ["BTC/USDT", "ETH/USDT", "SOL/USDT", "BNB/USDT", "LINK/USDT"]
+
+    results = await asyncio.gather(
+        *(executor.try_open_trade(entry_price=100.0, win_probability=0.7, symbol=sym)
+          for sym in symbols)
+    )
+    assert sum(results) <= 3
+    assert risk_manager.open_count == sum(results)
+    assert len(executor.open_positions) == sum(results)
+
+
+@pytest.mark.asyncio
+async def test_close_then_reopen_same_symbol(
+    risk_manager: RiskManager, mock_db: AsyncMock
+) -> None:
+    """After closing, the same symbol can be reopened."""
+    from execution.paper_executor import PaperExecutor
+
+    executor = PaperExecutor(db=mock_db, risk_manager=risk_manager)
+    await executor.try_open_trade(entry_price=100.0, win_probability=0.7, symbol="BTC/USDT")
+    assert "BTC/USDT" in executor.open_positions
+
+    # Drop below default SL (1.5% of 100 = 98.5) but not enough to trigger daily loss halt
+    pnl = await executor.check_and_close(current_price=98.0, symbol="BTC/USDT")
+    assert pnl is not None
+    assert "BTC/USDT" not in executor.open_positions
+    assert risk_manager.open_count == 0
+
+    reopened = await executor.try_open_trade(entry_price=98.0, win_probability=0.7, symbol="BTC/USDT")
+    assert reopened is True
+    assert risk_manager.open_count == 1
+
+
+def test_db_close_trade_exit_reason_param() -> None:
+    """Verify the close_trade query includes exit_reason parameter slot ($9)."""
+    from database.db_manager import _CLOSE_TRADE
+    assert "$9" in _CLOSE_TRADE
+    assert "exit_reason" in _CLOSE_TRADE
+
+
+def test_db_schema_has_lifecycle_columns() -> None:
+    """Verify the ALTER adds exit_reason, mt5_ticket, sl_price, tp_price."""
+    from database.db_manager import _ALTER_TRADES_HISTORY_METRICS
+    assert "exit_reason" in _ALTER_TRADES_HISTORY_METRICS
+    assert "mt5_ticket" in _ALTER_TRADES_HISTORY_METRICS
+    assert "sl_price" in _ALTER_TRADES_HISTORY_METRICS
+    assert "tp_price" in _ALTER_TRADES_HISTORY_METRICS


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cambios

### 1. Fix bugs críticos de race conditions (posiciones)

| Bug | Severidad | Causa raíz |
|-----|-----------|-----------|
| MT5 `try_open_trade` sin lock | **CRÍTICO** | Validaciones sin `_positions_lock` → >3 posiciones y duplicados |
| Paper `try_open_trade` TOCTOU | **CRÍTICO** | Lock liberado antes de escribir `open_positions` → SOL duplicado |
| MT5 sync sin lock | **ALTO** | Mutaciones de `open_positions` sin protección durante sync |
| Deriva del contador | **ALTO** | `register_open()` sin rollback en fallos → slots perdidos |

### 2. Fix filtro HTF trend
BUY ahora requiere `bullish` confirmado en 4H **Y** 1H. Neutral o bearish → HOLD.

### 3. Lifecycle tracking en DB
Nuevas columnas en `trades_history`: `exit_reason`, `mt5_ticket`, `sl_price`, `tp_price`.

### 4. Dashboard terminal (Rich) mejorado
- Header 3 columnas: sistema, IA, PnL/winrate sesión
- Barras de progreso mini para RSI y ML confidence
- Iconos de tendencia 🟢🔴🟡 para 15m/1H/4H
- Columna de señal: BUY/HOLD/TRAIL/CLOSE
- Tabla dedicada de posiciones con SL, TP, pico, PnL%, trailing, duración
- Panel de riesgo con Win/Loss y winrate
- Filas con color: verde profit, rojo loss

### 5. Dashboard web mejorado
- Fila de estadísticas sesión: Win/Loss, Winrate, Latencia API, gauge de sentimiento
- Contador de posiciones en header
- Estado del bot: Pausa/Operando/Listo
- API envía `session_wins`, `session_losses`, `session_winrate`, `open_count`, `max_positions`

### Tests
✅ 34/34 tests pasan (0 fallos)

### Archivos
- `execution/mt5_executor.py` — Locks, sync, counter invariant
- `execution/paper_executor.py` — Lock TOCTOU fix, rollback, win/loss tracking
- `strategy/ml_predictor.py` — HTF filter bullish-only
- `database/db_manager.py` — Lifecycle columns + exit_reason
- `bot/dashboard.py` — Terminal dashboard rewrite
- `bot/web_server.py` — Web dashboard + API enhancements
- `bot/state.py` — Session win/loss counters
- `tests/test_position_limits.py` — 13 new tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa94190d-486f-433b-87c4-1f653e1badc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa94190d-486f-433b-87c4-1f653e1badc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

